### PR TITLE
Improve experience when having multiple PDFs open

### DIFF
--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/PdfPageSpreadActionGroup.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/PdfPageSpreadActionGroup.kt
@@ -7,7 +7,7 @@ class PdfPageSpreadActionGroup : DefaultActionGroup() {
   override fun isPopup(): Boolean = true
 
   override fun update(event: AnActionEvent) {
-    event.presentation.isVisible = PdfAction.hasOpenedEditor(event)
+    event.presentation.isVisible = PdfAction.hasEditorInView(event)
     event.presentation.isEnabled = PdfAction.findController(event) != null
   }
 }

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/PdfSidebarViewModeActionGroup.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/PdfSidebarViewModeActionGroup.kt
@@ -7,7 +7,7 @@ class PdfSidebarViewModeActionGroup : DefaultActionGroup() {
   override fun isPopup(): Boolean = true
 
   override fun update(event: AnActionEvent) {
-    event.presentation.isVisible = PdfAction.hasOpenedEditor(event)
+    event.presentation.isVisible = PdfAction.hasEditorInView(event)
     event.presentation.isEnabled = PdfAction.findController(event) != null
   }
 }

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/search/PdfSearchAction.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/search/PdfSearchAction.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 
 sealed class PdfSearchAction(private val direction: SearchDirection) : PdfDumbAwareAction() {
   override fun actionPerformed(event: AnActionEvent) {
-    val editor = findEditor(event) ?: return
+    val editor = findEditorInView(event) ?: return
     val controller = findController(event) ?: return
     val searchQuery = editor.viewComponent.searchPanel.searchQuery
     controller.find(searchQuery, direction)
@@ -14,7 +14,7 @@ sealed class PdfSearchAction(private val direction: SearchDirection) : PdfDumbAw
 
   override fun update(event: AnActionEvent) {
     super.update(event)
-    val searchPanel = findEditor(event)?.viewComponent?.searchPanel
+    val searchPanel = findEditorInView(event)?.viewComponent?.searchPanel
     event.presentation.isEnabled = searchPanel?.searchText?.isNotEmpty() == true && searchPanel.isVisible
   }
 

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/search/PdfShowFindPopupAction.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/search/PdfShowFindPopupAction.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 
 class PdfShowFindPopupAction: PdfDumbAwareAction() {
   override fun actionPerformed(event: AnActionEvent) {
-    val searchPanel = findEditor(event)?.viewComponent?.searchPanel ?: return
+    val searchPanel = findEditorInView(event)?.viewComponent?.searchPanel ?: return
     if (!searchPanel.isVisible) {
       searchPanel.setEnabledState(true)
     }
@@ -14,7 +14,7 @@ class PdfShowFindPopupAction: PdfDumbAwareAction() {
   override fun update(event: AnActionEvent) {
     super.update(event)
     // TODO: Refactor
-    val searchPanel = findEditor(event)?.viewComponent?.searchPanel ?: return
+    val searchPanel = findEditorInView(event)?.viewComponent?.searchPanel ?: return
     event.presentation.isEnabled = !searchPanel.isVisible
   }
 }

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/view/PdfSetSidebarViewModeAction.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/view/PdfSetSidebarViewModeAction.kt
@@ -20,7 +20,7 @@ sealed class PdfSetSidebarViewModeAction(private val targetViewMode: SidebarView
 
   override fun update(event: AnActionEvent) {
     super.update(event)
-    event.presentation.isVisible = PdfAction.hasOpenedEditor(event)
+    event.presentation.isVisible = PdfAction.hasEditorInView(event)
     event.presentation.isEnabled = canBeEnabled(PdfAction.findController(event))
   }
 


### PR DESCRIPTION
When having multiple pdfs open most events would go to the first opened PDF instead of the PDF editor that the event belonged to.