### PR TITLE
Fix problems with the page count and add some shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@
 - Pages spread (even/odd)
 - Horizontal/vertical pages scroll directions
 
+## Shortcuts
+- **Move editor up or down:** up and down arrow keys.
+- **Move editor right or left:** right and left arrow keys.
+- **Move to the next page:** when the whole width of the page is in view, the right and left arrow keys will navigate to the next and previous page.
+- **Zoom in:** <kbd>Ctrl</kbd> + <kbd>+</kbd>, <kbd>Ctrl</kbd> + <kbd>=</kbd>.
+- **Zoom out:** <kbd>Ctrl</kbd> + <kbd>-</kbd>
+- **Reset zoom:** <kbd>Ctrl</kbd> + <kbd>0</kbd>
+- **Enter presentation mode:** <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>p</kbd>
+
 ### Features Notes
 
 * Text search will work only in text-based documents. For example, it won't work in all-images documents (books scans).

--- a/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/Application.kt
+++ b/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/Application.kt
@@ -257,10 +257,23 @@ class Application(private val viewer: ViewerAdapter) {
         event.preventDefault()
       }
     }
+
     window.addEventListener("keydown") { event: KeyboardEvent ->
       console.log(event)
       if (event.altKey && event.ctrlKey && event.key.lowercase() == "p") {
         viewer.viewerApp.requestPresentationMode()
+      }
+
+      if (event.key.lowercase() == "arrowright" && !event.altKey && !event.ctrlKey && !event.shiftKey) {
+        if (viewer.currentPageNumber < viewer.pagesCount) {
+          viewer.currentPageNumber += 1
+        }
+      }
+
+      if (event.key.lowercase() == "arrowleft" && !event.altKey && !event.ctrlKey && !event.shiftKey) {
+        if (viewer.currentPageNumber > 1) {
+          viewer.currentPageNumber -= 1
+        }
       }
     }
   }

--- a/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/Application.kt
+++ b/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/Application.kt
@@ -50,8 +50,8 @@ class Application(private val viewer: ViewerAdapter) {
     pipe.subscribe<IdeMessages.GotoPage> {
       console.log(it)
       when (it.direction) {
-        PageGotoDirection.FORWARD -> viewer.currentPageNumber += 1
-        PageGotoDirection.BACKWARD -> viewer.currentPageNumber -= 1
+        PageGotoDirection.FORWARD -> viewer.goToNextPage()
+        PageGotoDirection.BACKWARD -> viewer.goToPreviousPage()
       }
     }
     pipe.subscribe<IdeMessages.PageSpreadStateSetRequest> {
@@ -264,16 +264,35 @@ class Application(private val viewer: ViewerAdapter) {
         viewer.viewerApp.requestPresentationMode()
       }
 
+      // Go to the next page.
       if (event.key.lowercase() == "arrowright" && !event.altKey && !event.ctrlKey && !event.shiftKey) {
-        if (viewer.currentPageNumber < viewer.pagesCount) {
-          viewer.currentPageNumber += 1
+        // Only move to the next page if the entire width of the page is in view.
+        if (viewer.zoomState.value < 100) {
+          viewer.goToNextPage()
         }
       }
 
+      // Go to the previous page.
       if (event.key.lowercase() == "arrowleft" && !event.altKey && !event.ctrlKey && !event.shiftKey) {
-        if (viewer.currentPageNumber > 1) {
-          viewer.currentPageNumber -= 1
+        // Only move to the next page if the entire width of the page is in view.
+        if (viewer.zoomState.value < 100) {
+          viewer.goToPreviousPage()
         }
+      }
+
+      // Zoom in.
+      if ((event.key.lowercase() == "=" || event.key.lowercase() == "+") && event.ctrlKey && !event.altKey && !event.shiftKey) {
+        viewer.increaseScale()
+      }
+
+      // Zoom out.
+      if (event.key.lowercase() == "-" && event.ctrlKey && !event.altKey && !event.shiftKey) {
+        viewer.decreaseScale()
+      }
+
+      // Reset zoom.
+      if (event.key.lowercase() == "0" && event.ctrlKey && !event.altKey && !event.shiftKey) {
+        viewer.viewerApp.pdfViewer.currentScaleValue = "auto"
       }
     }
   }

--- a/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/pdfjs/ViewerAdapter.kt
+++ b/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/pdfjs/ViewerAdapter.kt
@@ -13,7 +13,7 @@ class ViewerAdapter(val viewerApp: PdfViewerApplication) {
     get() = viewerApp.pdfViewer.pagesCount
 
   var currentPageNumber: Int
-    get() = viewerApp.pdfViewer._location.pageNumber
+    get() = viewerApp.pdfViewer.currentPageNumber
     set(value) {
       require(value in 1..pagesCount)
       viewerApp.pdfViewer.currentPageNumber = value

--- a/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/pdfjs/ViewerAdapter.kt
+++ b/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/pdfjs/ViewerAdapter.kt
@@ -58,6 +58,18 @@ class ViewerAdapter(val viewerApp: PdfViewerApplication) {
     viewerApp.asDynamic().appConfig.secondaryToolbar.pageRotateCcwButton.click()
   }
 
+  fun goToNextPage() {
+    if (currentPageNumber < pagesCount) {
+      currentPageNumber += 1
+    }
+  }
+
+  fun goToPreviousPage() {
+    if (currentPageNumber > 1) {
+      currentPageNumber -= 1
+    }
+  }
+
   fun findNext(text: String) {
     val findBar = viewerApp.asDynamic().appConfig.findBar
     findBar.findField.value = text

--- a/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/pdfjs/types/PdfViewer.kt
+++ b/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/pdfjs/types/PdfViewer.kt
@@ -11,5 +11,5 @@ external class PdfViewer {
   val pagesCount: Int
   var currentPageNumber: Int
   val currentScale: Int
-  val currentScaleValue: String
+  var currentScaleValue: String
 }


### PR DESCRIPTION
Resolves #68, fixes #67

- Fix the problem with the inconsistent page count and the next/previous page buttons not working (#67)
- Add the right and left arrow keys as shortcuts for next/previous page when the page is entirely in view (#68)
- Add shortcuts for zooming in and out
- Add shortcut to reset zoom