### PR TITLE
Open links in external browser, workaround for #38

### DIFF
--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/ui/editor/view/PdfJcefPreviewController.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/ui/editor/view/PdfJcefPreviewController.kt
@@ -41,7 +41,9 @@ class PdfJcefPreviewController(val project: Project, val virtualFile: VirtualFil
   DumbAware
 {
   // TODO: Migrate to OSR when it's ready
-  val browser = JCEFHtmlPanel(useOsr, null, "about:blank")
+  val browser = JCEFHtmlPanel(useOsr, null, "about:blank").apply {
+    setOpenLinksInExternalBrowser(true)
+  }
   val pipe = JcefBrowserMessagePipe(browser)
   val presentationController = PdfPresentationController(this)
   private val messageBusConnection = project.messageBus.connect(this)


### PR DESCRIPTION
Sort of fixes #38. I could not find a way to be able to go back to the pdf after following a link (when following a link, the reference to the `messagePipe` gets lost). 

After some thought I think it's perfectly okay to open links from within a pdf in an external browser (it's definitely an improvement of the current behaviour), you probably want to be able to go back and forth between the pdf and the opened link easily anyway. Though I think the ideal situation would be to open the link in a new browser tab within the IDE, I didn't find a(n easy) way to do so currently. 