### PR TITLE
Allow reloading of a corrupt pdf file

### DIFF
--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/ui/editor/view/PdfJcefPreviewController.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/ui/editor/view/PdfJcefPreviewController.kt
@@ -147,10 +147,12 @@ class PdfJcefPreviewController(val project: Project, val virtualFile: VirtualFil
   }
 
   fun reload(tryToPreserveState: Boolean = false) {
-    if (viewLoaded && isReloading.compareAndSet(false, true)) {
-      when (tryToPreserveState) {
+    if (isReloading.compareAndSet(false, true)) {
+      // Reloading while preserving the state only makes sense if the pdf was loaded and we wanted to preserve state.
+      // Reloading without state should always be available, e.g., a corrupt pdf that was still open could have been fixed and can now be reloaded.
+      when (viewLoaded && tryToPreserveState) {
         true -> pipe.send(IdeMessages.BeforeReload())
-        else -> doActualReload(tryToPreserveState)
+        else -> doActualReload(false)
       }
     }
   }


### PR DESCRIPTION
Hopefully fixes #37. It at least fixes the [example](https://github.com/FirstTimeInForever/intellij-pdf-viewer/issues/37#issuecomment-1513656801) proposed by @PHPirates, and I feel positive that it fixes some of the other cases I could not reproduce.