### PR TITLE
Fix the color inversion

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ version = 0.14.3
 
 #IntelliJ IDEA 2021.1.2 Preview
 platformVersion = 2023.1
-pluginSinceVersion = 213.6777.52
+pluginSinceVersion = 223.1
 pluginUntilVersion = 299.*
 pluginVerifierIdeVersions = 213.6777.52, 221.3427.89, 221.4906.8
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,21 +1,21 @@
 pluginName = intellij-pdf-viewer
 group = com.firsttimeinforever.intellij.pdf.viewer
-version = 0.14.0
+version = 0.14.3
 
 # To run with AS 2021.3.1 Canary 5
 #platformVersion = 213.6777.52
 
 #IntelliJ IDEA 2021.1.2 Preview
-platformVersion = 2021.3.2
+platformVersion = 2023.1
 pluginSinceVersion = 213.6777.52
 pluginUntilVersion = 299.*
 pluginVerifierIdeVersions = 213.6777.52, 221.3427.89, 221.4906.8
 
-texifyVersion = 0.7.14
+texifyVersion = 0.7.29
 
 nodeVersion = 15.5.1
 
-kotlinVersion = 1.6.0
+kotlinVersion = 1.8.0
 kotlinxSerializationJsonVersion = 1.2.1
 
 kotlin.code.style = official

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -113,6 +113,8 @@ tasks.getByName("processResources") {
 }
 
 tasks.withType<RunIdeTask> {
+  // Some warning asked for this to be set explicitly
+  systemProperties["idea.log.path"] = file("build/idea-sandbox/system/log").absolutePath
   systemProperties["ide.browser.jcef.enabled"] = true
   systemProperties["pdf.viewer.debug"] = true
   jvmArgs("--add-exports", "java.base/jdk.internal.vm=ALL-UNNAMED", "-Xmx4096m", "-Xms128m")

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
   id("java")
   kotlin("jvm")
   kotlin("plugin.serialization")
-  id("org.jetbrains.intellij") version "1.3.1"
+  id("org.jetbrains.intellij") version "1.10.1"
   id("org.jetbrains.changelog") version "1.1.2"
   id("com.github.ben-manes.versions") version "0.41.0"
 }
@@ -60,7 +60,7 @@ intellij {
 tasks {
   compileKotlin {
     kotlinOptions {
-      jvmTarget = JavaVersion.VERSION_11.toString()
+      jvmTarget = JavaVersion.VERSION_17.toString()
       @Suppress("SuspiciousCollectionReassignment")
       freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
     }

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/PdfAction.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/PdfAction.kt
@@ -24,7 +24,7 @@ abstract class PdfAction(protected val viewModeAwareness: ViewModeAwareness = Vi
 
   protected fun adjustPresentationVisibility(event: AnActionEvent) {
     val controller = findController(event) ?: return
-    val idePresentation = UISettings.instance.presentationMode
+    val idePresentation = UISettings.getInstance().presentationMode
     val documentPresentation = controller.presentationController.isPresentationModeActive
     event.presentation.isEnabledAndVisible = when (viewModeAwareness) {
       ViewModeAwareness.NONE -> !idePresentation && !documentPresentation

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/presentation/PdfToggleIdePresentationModeAction.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/presentation/PdfToggleIdePresentationModeAction.kt
@@ -8,6 +8,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 
 class PdfToggleIdePresentationModeAction: PdfDumbAwareAction(ViewModeAwareness.BOTH) {
   override fun actionPerformed(event: AnActionEvent) {
-    TogglePresentationModeAction.setPresentationMode(event.project, !UISettings.instance.presentationMode)
+    TogglePresentationModeAction.setPresentationMode(event.project, !UISettings.getInstance().presentationMode)
   }
 }

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/view/PdfToggleInvertDocumentColorsAction.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/view/PdfToggleInvertDocumentColorsAction.kt
@@ -13,11 +13,4 @@ class PdfToggleInvertDocumentColorsAction : PdfToggleAction(ViewModeAwareness.BO
     PdfViewerSettings.instance.invertDocumentColors = state
     PdfViewerSettings.instance.notifyListeners()
   }
-
-  override fun update(event: AnActionEvent) {
-    super.update(event)
-    if (!PdfViewerSettings.enableExperimentalFeatures) {
-      event.presentation.isEnabledAndVisible = false
-    }
-  }
 }

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/view/PdfToggleInvertDocumentColorsAction.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/view/PdfToggleInvertDocumentColorsAction.kt
@@ -5,7 +5,6 @@ import com.firsttimeinforever.intellij.pdf.viewer.actions.ViewModeAwareness
 import com.firsttimeinforever.intellij.pdf.viewer.settings.PdfViewerSettings
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAware
-import com.intellij.openapi.util.IconLoader
 
 class PdfToggleInvertDocumentColorsAction : PdfToggleAction(ViewModeAwareness.BOTH), DumbAware {
 
@@ -14,17 +13,5 @@ class PdfToggleInvertDocumentColorsAction : PdfToggleAction(ViewModeAwareness.BO
   override fun setSelected(event: AnActionEvent, state: Boolean) {
     PdfViewerSettings.instance.invertDocumentColors = state
     PdfViewerSettings.instance.notifyListeners()
-  }
-
-  override fun update(event: AnActionEvent) {
-    event.presentation.apply {
-      icon = if (PdfViewerSettings.instance.invertDocumentColors) {
-        IconLoader.getIcon("expui/meetNewUi/lightTheme.svg", this::class.java.classLoader)
-      } else {
-        IconLoader.getIcon("expui/meetNewUi/darkTheme.svg", this::class.java.classLoader)
-      }
-      selectedIcon = icon
-    }
-    super.update(event)
   }
 }

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/view/PdfToggleInvertDocumentColorsAction.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/view/PdfToggleInvertDocumentColorsAction.kt
@@ -5,12 +5,26 @@ import com.firsttimeinforever.intellij.pdf.viewer.actions.ViewModeAwareness
 import com.firsttimeinforever.intellij.pdf.viewer.settings.PdfViewerSettings
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.util.IconLoader
 
 class PdfToggleInvertDocumentColorsAction : PdfToggleAction(ViewModeAwareness.BOTH), DumbAware {
+
   override fun isSelected(event: AnActionEvent) = PdfViewerSettings.instance.invertDocumentColors
 
   override fun setSelected(event: AnActionEvent, state: Boolean) {
     PdfViewerSettings.instance.invertDocumentColors = state
     PdfViewerSettings.instance.notifyListeners()
+  }
+
+  override fun update(event: AnActionEvent) {
+    event.presentation.apply {
+      icon = if (PdfViewerSettings.instance.invertDocumentColors) {
+        IconLoader.getIcon("expui/meetNewUi/lightTheme.svg", this::class.java.classLoader)
+      } else {
+        IconLoader.getIcon("expui/meetNewUi/darkTheme.svg", this::class.java.classLoader)
+      }
+      selectedIcon = icon
+    }
+    super.update(event)
   }
 }

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/view/PdfToggleInvertDocumentColorsAction.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/view/PdfToggleInvertDocumentColorsAction.kt
@@ -14,4 +14,9 @@ class PdfToggleInvertDocumentColorsAction : PdfToggleAction(ViewModeAwareness.BO
     PdfViewerSettings.instance.invertDocumentColors = state
     PdfViewerSettings.instance.notifyListeners()
   }
+
+  override fun update(event: AnActionEvent) {
+    super.update(event)
+    event.presentation.isEnabledAndVisible = !PdfViewerSettings.instance.invertColorsWithTheme
+  }
 }

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/report/PdfErrorReportSubmitter.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/report/PdfErrorReportSubmitter.kt
@@ -28,7 +28,7 @@ internal class PdfErrorReportSubmitter : ErrorReportSubmitter() {
   override fun getReportActionText(): String = PdfViewerBundle.message("pdf.viewer.error.report.action.text")
 
   override fun submit(
-    events: Array<out IdeaLoggingEvent>?,
+    events: Array<out IdeaLoggingEvent>,
     additionalInfo: String?,
     parentComponent: Component,
     consumer: Consumer<in SubmittedReportInfo>

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/report/PdfErrorReportSubmitter.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/report/PdfErrorReportSubmitter.kt
@@ -34,7 +34,7 @@ internal class PdfErrorReportSubmitter : ErrorReportSubmitter() {
     consumer: Consumer<in SubmittedReportInfo>
   ): Boolean {
     val context = DataManager.getInstance().getDataContext(parentComponent)
-    val event = createEvent(events ?: emptyArray())
+    val event = createEvent(events)
       .withMessage(additionalInfo ?: "No additional info were provided")
       .also { attachExtraInfo(it) }
     val project = CommonDataKeys.PROJECT.getData(context)

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/settings/PdfViewerConfigurable.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/settings/PdfViewerConfigurable.kt
@@ -11,12 +11,14 @@ class PdfViewerConfigurable : Configurable {
   override fun isModified(): Boolean {
     return settingsForm?.run {
       settings.enableDocumentAutoReload != enableDocumentAutoReload.get() ||
-        settings.useCustomColors != useCustomColors ||
-        settings.customBackgroundColor != (customBackgroundColor?.rgb ?: settings.customBackgroundColor) ||
-        settings.customForegroundColor != (customForegroundColor?.rgb ?: settings.customForegroundColor) ||
-        settings.customIconColor != (customIconColor?.rgb ?: settings.customIconColor) ||
-        settings.documentColorsInvertIntensity != documentColorsInvertIntensity ||
-        settings.defaultSidebarViewMode != defaultSidebarViewMode.get()
+        settings.defaultSidebarViewMode != defaultSidebarViewMode.get() ||
+        settings.invertColorsWithTheme != invertDocumentColorsWithTheme.get() ||
+        settings.invertDocumentColors != invertDocumentColors.get() ||
+        settings.documentColorsInvertIntensity != documentColorsInvertIntensity.get() ||
+        settings.useCustomColors != useCustomColors.get() ||
+        settings.customForegroundColor != customForegroundColor.get() ||
+        settings.customBackgroundColor != customBackgroundColor.get() ||
+        settings.customIconColor != customIconColor.get()
     } ?: false
   }
 
@@ -26,12 +28,14 @@ class PdfViewerConfigurable : Configurable {
     val wasModified = isModified
     settings.run {
       enableDocumentAutoReload = settingsForm?.enableDocumentAutoReload?.get() ?: enableDocumentAutoReload
-      useCustomColors = settingsForm?.useCustomColors ?: useCustomColors
-      customBackgroundColor = settingsForm?.customBackgroundColor?.rgb ?: customBackgroundColor
-      customForegroundColor = settingsForm?.customForegroundColor?.rgb ?: customForegroundColor
-      customIconColor = settingsForm?.customIconColor?.rgb ?: customIconColor
-      documentColorsInvertIntensity = settingsForm?.documentColorsInvertIntensity ?: documentColorsInvertIntensity
       defaultSidebarViewMode = settingsForm?.defaultSidebarViewMode?.get() ?: defaultSidebarViewMode
+      invertColorsWithTheme = settingsForm?.invertDocumentColorsWithTheme?.get() ?: invertColorsWithTheme
+      invertDocumentColors = settingsForm?.invertDocumentColors?.get() ?: invertDocumentColors
+      documentColorsInvertIntensity = settingsForm?.documentColorsInvertIntensity?.get() ?: documentColorsInvertIntensity
+      useCustomColors = settingsForm?.useCustomColors?.get() ?: useCustomColors
+      customBackgroundColor = settingsForm?.customBackgroundColor?.get() ?: customBackgroundColor
+      customForegroundColor = settingsForm?.customForegroundColor?.get() ?: customForegroundColor
+      customIconColor = settingsForm?.customIconColor?.get() ?: customIconColor
     }
     if (wasModified) {
       settings.notifyListeners()
@@ -39,7 +43,7 @@ class PdfViewerConfigurable : Configurable {
   }
 
   override fun reset() {
-    settingsForm?.loadSettings()
+    settingsForm?.reset()
   }
 
   override fun createComponent(): JComponent? {

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/settings/PdfViewerInvertColorsListener.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/settings/PdfViewerInvertColorsListener.kt
@@ -1,0 +1,15 @@
+package com.firsttimeinforever.intellij.pdf.viewer.settings
+
+import com.intellij.openapi.editor.colors.EditorColorsListener
+import com.intellij.openapi.editor.colors.EditorColorsScheme
+import com.intellij.ui.ColorUtil
+
+class PdfViewerInvertColorsListener : EditorColorsListener {
+  override fun globalSchemeChange(scheme: EditorColorsScheme?) {
+    if (PdfViewerSettings.instance.invertColorsWithTheme) {
+      val backGround = scheme?.defaultBackground ?: return
+      PdfViewerSettings.instance.invertDocumentColors = ColorUtil.isDark(backGround)
+      PdfViewerSettings.instance.notifyListeners()
+    }
+  }
+}

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/settings/PdfViewerSettings.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/settings/PdfViewerSettings.kt
@@ -19,8 +19,7 @@ class PdfViewerSettings : PersistentStateComponent<PdfViewerSettings> {
   var customIconColor: Int = defaultIconColor.rgb
   var enableDocumentAutoReload = true
   var documentColorsInvertIntensity: Int = defaultDocumentColorsInvertIntensity
-  var invertDocumentColors = false
-    get() = field && enableExperimentalFeatures
+  var invertDocumentColors = true
 
   var defaultSidebarViewMode: SidebarViewMode = SidebarViewMode.THUMBNAILS
 

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/settings/PdfViewerSettings.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/settings/PdfViewerSettings.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.util.messages.Topic
 import com.intellij.util.xmlb.XmlSerializerUtil.copyBean
+import java.awt.Color
 
 @State(name = "PdfViewerSettings", storages = [(Storage("pdf_viewer.xml"))])
 class PdfViewerSettings : PersistentStateComponent<PdfViewerSettings> {
@@ -19,7 +20,8 @@ class PdfViewerSettings : PersistentStateComponent<PdfViewerSettings> {
   var customIconColor: Int = defaultIconColor.rgb
   var enableDocumentAutoReload = true
   var documentColorsInvertIntensity: Int = defaultDocumentColorsInvertIntensity
-  var invertDocumentColors = true
+  var invertDocumentColors = false
+  var invertColorsWithTheme = false
 
   var defaultSidebarViewMode: SidebarViewMode = SidebarViewMode.THUMBNAILS
 

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/settings/PdfViewerSettingsForm.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/settings/PdfViewerSettingsForm.kt
@@ -2,6 +2,7 @@ package com.firsttimeinforever.intellij.pdf.viewer.settings
 
 import com.firsttimeinforever.intellij.pdf.viewer.PdfViewerBundle
 import com.firsttimeinforever.intellij.pdf.viewer.model.SidebarViewMode
+import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.observable.properties.PropertyGraph
 import com.intellij.openapi.observable.util.not
 import com.intellij.ui.ColorPanel
@@ -16,8 +17,10 @@ class PdfViewerSettingsForm : JPanel() {
   private val settings
     get() = PdfViewerSettings.instance
 
-  val enableDocumentAutoReload = PropertyGraph().property(settings.enableDocumentAutoReload)
-  val defaultSidebarViewMode = PropertyGraph().property(settings.defaultSidebarViewMode)
+  private val properties = PropertyGraph()
+
+  val enableDocumentAutoReload = properties.property(settings.enableDocumentAutoReload)
+  val defaultSidebarViewMode = properties.property(settings.defaultSidebarViewMode)
 
   private val generalSettingsGroup = panel {
     group(PdfViewerBundle.message("pdf.viewer.settings.group.general")) {
@@ -41,9 +44,14 @@ class PdfViewerSettingsForm : JPanel() {
     }
   }
 
-  val invertDocumentColorsWithTheme = PropertyGraph().property(settings.invertColorsWithTheme)
-  val invertDocumentColors = PropertyGraph().property(settings.invertDocumentColors)
-  val documentColorsInvertIntensity = PropertyGraph().property(settings.documentColorsInvertIntensity)
+  val invertDocumentColorsWithTheme = properties.property(settings.invertColorsWithTheme).apply {
+    afterPropagation {
+      // Automatically toggle the invertDocumentColors checkbox so the pdf color switched to the current theme.
+      if (this.get()) invertDocumentColors.set(EditorColorsManager.getInstance().isDarkEditor)
+    }
+  }
+  val invertDocumentColors = properties.property(settings.invertDocumentColors)
+  val documentColorsInvertIntensity = properties.property(settings.documentColorsInvertIntensity)
 
   private val invertColorsGroup = panel {
     group(PdfViewerBundle.message("pdf.viewer.settings.group.colors.document")) {
@@ -65,10 +73,10 @@ class PdfViewerSettingsForm : JPanel() {
     }
   }
 
-  val useCustomColors = PropertyGraph().property(settings.useCustomColors)
-  val customBackgroundColor = PropertyGraph().property(settings.customBackgroundColor)
-  val customForegroundColor = PropertyGraph().property(settings.customForegroundColor)
-  val customIconColor = PropertyGraph().property(settings.customIconColor)
+  val useCustomColors = properties.property(settings.useCustomColors)
+  val customBackgroundColor = properties.property(settings.customBackgroundColor)
+  val customForegroundColor = properties.property(settings.customForegroundColor)
+  val customIconColor = properties.property(settings.customIconColor)
 
   private val backgroundColorPanel = ColorPanel().apply {
     selectedColor = Color(customBackgroundColor.get())
@@ -137,7 +145,7 @@ class PdfViewerSettingsForm : JPanel() {
     customIconColor.set(settings.customIconColor)
   }
 
-  fun resetViewerColorsToTheme() {
+  private fun resetViewerColorsToTheme() {
     PdfViewerSettings.run {
       backgroundColorPanel.selectedColor = defaultBackgroundColor
       customBackgroundColor.set(defaultBackgroundColor.rgb)

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/settings/PdfViewerSettingsForm.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/settings/PdfViewerSettingsForm.kt
@@ -50,6 +50,7 @@ class PdfViewerSettingsForm : JPanel() {
       row {
         checkBox(PdfViewerBundle.message("pdf.viewer.settings.colors.document.with.theme"))
           .bindSelected(invertDocumentColorsWithTheme)
+          .comment(PdfViewerBundle.message("pdf.viewer.settings.colors.document.with.theme.comment"))
       }
       row {
         checkBox(PdfViewerBundle.message("pdf.viewer.settings.colors.document.invert"))
@@ -59,6 +60,7 @@ class PdfViewerSettingsForm : JPanel() {
       row(PdfViewerBundle.message("pdf.viewer.settings.colors.document.invert.intensity")) {
         intTextField(1..100, 1)
           .bindIntText(documentColorsInvertIntensity)
+        rowComment(PdfViewerBundle.message("pdf.viewer.settings.colors.document.invert.intensity.comment"))
       }
     }
   }
@@ -90,25 +92,27 @@ class PdfViewerSettingsForm : JPanel() {
       row {
         checkBox(PdfViewerBundle.message("pdf.viewer.settings.viewer.colors"))
           .bindSelected(useCustomColors)
+          .comment(PdfViewerBundle.message("pdf.viewer.settings.group.colors.viewer.comment"))
       }
-      row {
-        panel {
-          row(PdfViewerBundle.message("pdf.viewer.settings.foreground")) {
-            cell(foregroundColorPanel)
-          }
-          row(PdfViewerBundle.message("pdf.viewer.settings.background")) {
-            cell(backgroundColorPanel)
-          }
-          row(PdfViewerBundle.message("pdf.viewer.settings.icons")) {
-            cell(iconColorPanel)
-          }
-          row {
-            link(PdfViewerBundle.message("pdf.viewer.settings.set.current.theme")) {
-              resetViewerColorsToTheme()
+      indent {
+          panel {
+            row(PdfViewerBundle.message("pdf.viewer.settings.foreground")) {
+              cell(foregroundColorPanel)
             }
-          }
-        }
-      }.enabledIf(useCustomColors)
+            row(PdfViewerBundle.message("pdf.viewer.settings.background")) {
+              cell(backgroundColorPanel)
+            }
+            row(PdfViewerBundle.message("pdf.viewer.settings.icons")) {
+              cell(iconColorPanel)
+              rowComment(PdfViewerBundle.message("pdf.viewer.settings.icons.color.notice"))
+            }
+            row {
+              link(PdfViewerBundle.message("pdf.viewer.settings.set.current.theme")) {
+                resetViewerColorsToTheme()
+              }
+            }
+          }.enabledIf(useCustomColors)
+      }
     }
   }
 

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/settings/PdfViewerSettingsForm.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/settings/PdfViewerSettingsForm.kt
@@ -45,7 +45,7 @@ class PdfViewerSettingsForm : JPanel() {
     "Invert Colors Intensity",
     settings.documentColorsInvertIntensity
   ).also {
-    it.isEnabled = PdfViewerSettings.enableExperimentalFeatures
+    it.isEnabled = true
   }
 
   val enableDocumentAutoReload = PropertyGraph().graphProperty { settings.enableDocumentAutoReload }
@@ -144,46 +144,44 @@ class PdfViewerSettingsForm : JPanel() {
           label(PdfViewerBundle.message("pdf.viewer.settings.icons.color.notice"))
         }
       }
-      if (PdfViewerSettings.enableExperimentalFeatures) {
-        titledRow("Experimental Features") {
-          row {
-            object : JPanel(GridBagLayout()) {
-              init {
-                GridBagConstraints().also {
-                  it.anchor = GridBagConstraints.LINE_START
-                  it.ipadx = 8
-                  add(JLabel("Colors invert intensity:"), it)
-                  val field = JBTextField(documentColorsInvertIntensity.toString(), 5)
-                  field.document.addDocumentListener(object : DocumentListener {
-                    override fun insertUpdate(e: DocumentEvent?) {
-                      documentColorsInvertIntensity = field.text.toIntOrNull() ?: 0
-                    }
+      titledRow("Experimental Features") {
+        row {
+          object : JPanel(GridBagLayout()) {
+            init {
+              GridBagConstraints().also {
+                it.anchor = GridBagConstraints.LINE_START
+                it.ipadx = 8
+                add(JLabel("Colors invert intensity:"), it)
+                val field = JBTextField(documentColorsInvertIntensity.toString(), 5)
+                field.document.addDocumentListener(object : DocumentListener {
+                  override fun insertUpdate(e: DocumentEvent?) {
+                    documentColorsInvertIntensity = field.text.toIntOrNull() ?: 0
+                  }
 
-                    override fun removeUpdate(e: DocumentEvent?) {
-                      documentColorsInvertIntensity = field.text.toIntOrNull() ?: 0
-                    }
+                  override fun removeUpdate(e: DocumentEvent?) {
+                    documentColorsInvertIntensity = field.text.toIntOrNull() ?: 0
+                  }
 
-                    override fun changedUpdate(e: DocumentEvent?) {
-                      documentColorsInvertIntensity = field.text.toIntOrNull() ?: 0
-                    }
-                  })
-                  add(field, it)
-                }
+                  override fun changedUpdate(e: DocumentEvent?) {
+                    documentColorsInvertIntensity = field.text.toIntOrNull() ?: 0
+                  }
+                })
+                add(field, it)
               }
-            }()
-          }
+            }
+          }()
         }
         // This is a preferred way for implementing this UI component.
         // Unfortunately, this is not working due to unstable UI DSL.
-        // titledRow("Experimental Features") {
-        //     row {
-        //         label("Please note, that this features are experimental and may not work as expected.")
-        //     }
-        //     row {
-        //         label("Colors invert intensity")
-        //         intTextField(::documentColorsInvertIntensity, 1, 0..100)
-        //     }
-        // }
+//         titledRow("Experimental Features") {
+//             row {
+//                 label("Please note, that this features are experimental and may not work as expected.")
+//             }
+//             row {
+//                 label("Colors invert intensity")
+//                 intTextField(::documentColorsInvertIntensity, 1, 0..100)
+//             }
+//         }
       }
     })
     loadSettings()

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/tex/TexPdfViewer.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/tex/TexPdfViewer.kt
@@ -67,7 +67,7 @@ class TexPdfViewer : ExternalPdfViewer {
           editor as PdfFileEditor
         } else {
           val editorWindow = OpenInRightSplitAction.openInRightSplit(project, file, pdfEditor, requestFocus = false)
-          editorWindow?.selectedEditor?.selectedWithProvider?.fileEditor as PdfFileEditor
+          editorWindow?.selectedComposite?.selectedWithProvider?.fileEditor as PdfFileEditor
         }
 
         val command = GeneralCommandLine(

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/ui/editor/PdfEditorUtils.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/ui/editor/PdfEditorUtils.kt
@@ -8,7 +8,7 @@ import com.intellij.openapi.vfs.VirtualFile
 
 object PdfEditorUtils {
   fun findPdfEditor(project: Project, file: VirtualFile): PdfFileEditor? {
-    val editorManager = FileEditorManagerEx.getInstance(project) ?: return null
+    val editorManager = FileEditorManagerEx.getInstanceEx(project)
     val selectedEditor = editorManager.getSelectedEditor(file) as? PdfFileEditor
     if (selectedEditor != null) {
       return selectedEditor

--- a/plugin/src/main/resources/META-INF/actions.xml
+++ b/plugin/src/main/resources/META-INF/actions.xml
@@ -144,8 +144,6 @@
       <reference ref="pdf.viewer.IncreaseScaleAction"/>
       <reference ref="pdf.viewer.DecreaseScaleAction"/>
       <separator/>
-      <reference ref="pdf.viewer.ToggleInvertDocumentColorsAction"/>
-      <separator/>
       <reference ref="pdf.viewer.SetPageSpreadNoneAction"/>
       <reference ref="pdf.viewer.SetPageSpreadOddAction"/>
       <reference ref="pdf.viewer.SetPageSpreadEvenAction"/>

--- a/plugin/src/main/resources/META-INF/actions.xml
+++ b/plugin/src/main/resources/META-INF/actions.xml
@@ -144,6 +144,8 @@
       <reference ref="pdf.viewer.IncreaseScaleAction"/>
       <reference ref="pdf.viewer.DecreaseScaleAction"/>
       <separator/>
+      <reference ref="pdf.viewer.ToggleInvertDocumentColorsAction"/>
+      <separator/>
       <reference ref="pdf.viewer.SetPageSpreadNoneAction"/>
       <reference ref="pdf.viewer.SetPageSpreadOddAction"/>
       <reference ref="pdf.viewer.SetPageSpreadEvenAction"/>

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -25,7 +25,8 @@
     <applicationService serviceImplementation="com.firsttimeinforever.intellij.pdf.viewer.settings.PdfViewerSettings"/>
     <applicationConfigurable instance="com.firsttimeinforever.intellij.pdf.viewer.settings.PdfViewerConfigurable"/>
     <errorHandler implementation="com.firsttimeinforever.intellij.pdf.viewer.report.PdfErrorReportSubmitter"/>
-    <statusBarWidgetFactory implementation="com.firsttimeinforever.intellij.pdf.viewer.ui.widgets.PdfDocumentPageStatusBarWidgetFactory"/>
+    <statusBarWidgetFactory id="com.firsttimeinforever.intellij.pdf.viewer.ui.widgets.PdfDocumentPageStatusBarWidget"
+                            implementation="com.firsttimeinforever.intellij.pdf.viewer.ui.widgets.PdfDocumentPageStatusBarWidgetFactory"/>
   </extensions>
 
   <applicationListeners>

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -32,6 +32,8 @@
   <applicationListeners>
     <listener class="com.firsttimeinforever.intellij.pdf.viewer.ui.widgets.PdfStatusBarProjectManagerListener"
               topic="com.intellij.openapi.project.ProjectManagerListener"/>
+    <listener class="com.firsttimeinforever.intellij.pdf.viewer.settings.PdfViewerInvertColorsListener"
+              topic="com.intellij.openapi.editor.colors.EditorColorsListener"/>
   </applicationListeners>
 
   <xi:include href="/META-INF/actions.xml" xpointer="xpointer(/idea-plugin/*)"/>

--- a/plugin/src/main/resources/messages/PdfViewerActionsBundle.properties
+++ b/plugin/src/main/resources/messages/PdfViewerActionsBundle.properties
@@ -18,7 +18,7 @@ action.pdf.viewer.ToggleScrollDirectionAction.text=Set Vertical Scrolling
 action.pdf.viewer.ToggleScrollDirectionAction.description=Sets vertical scrolling for document pages
 
 action.pdf.viewer.ToggleInvertDocumentColorsAction.text=Invert Document Colors
-action.pdf.viewer.ToggleInvertDocumentColorsAction.description=Applies invert filter to every document page (experimental)
+action.pdf.viewer.ToggleInvertDocumentColorsAction.description=Applies invert filter to every document page
 
 # Sidebar view mode actions
 

--- a/plugin/src/main/resources/messages/PdfViewerBundle.properties
+++ b/plugin/src/main/resources/messages/PdfViewerBundle.properties
@@ -15,14 +15,19 @@ pdf.viewer.document.info.page.size=Page Size
 pdf.viewer.document.info.linearized=Linearized
 
 pdf.viewer.settings.display.name=PDF Viewer
+pdf.viewer.settings.group.general=General
 pdf.viewer.settings.reload.document=Reload document on change
 pdf.viewer.settings.sidebar.viewer.default=Default sidebar view mode
-pdf.viewer.settings.group.colors.document=Document colors
+
+pdf.viewer.settings.group.colors.document=Document Colors
 pdf.viewer.settings.colors.document.with.theme=Invert document colors based on theme
+pdf.viewer.settings.colors.document.with.theme.comment=Document colors will be inverted on dark theme, real document colors will be used on light theme
 pdf.viewer.settings.colors.document.invert=Invert document colors
 pdf.viewer.settings.colors.document.invert.intensity=Colors invert intensity
-pdf.viewer.settings.group.colors.viewer=Viewer colors
-pdf.viewer.settings.group.general=General
+pdf.viewer.settings.colors.document.invert.intensity.comment=The higher this number, the higher the contrast of the document with inverted colors. When set to 100 (the maximum) white becomes black, for 85 (the default) white becomes dark gray
+
+pdf.viewer.settings.group.colors.viewer=Viewer Colors
+pdf.viewer.settings.group.colors.viewer.comment=Edits the colors of the viewer/editor, not the colors of the PDF itself
 pdf.viewer.settings.viewer.colors=Use custom colors
 pdf.viewer.settings.background=Background:
 pdf.viewer.settings.foreground=Foreground:

--- a/plugin/src/main/resources/messages/PdfViewerBundle.properties
+++ b/plugin/src/main/resources/messages/PdfViewerBundle.properties
@@ -16,9 +16,14 @@ pdf.viewer.document.info.linearized=Linearized
 
 pdf.viewer.settings.display.name=PDF Viewer
 pdf.viewer.settings.reload.document=Reload document on change
-pdf.viewer.settings.use.custom.colors=Use custom colors
-pdf.viewer.settings.general=General
-pdf.viewer.settings.viewer.colors=Viewer Colors
+pdf.viewer.settings.sidebar.viewer.default=Default sidebar view mode
+pdf.viewer.settings.group.colors.document=Document colors
+pdf.viewer.settings.colors.document.with.theme=Invert document colors based on theme
+pdf.viewer.settings.colors.document.invert=Invert document colors
+pdf.viewer.settings.colors.document.invert.intensity=Colors invert intensity
+pdf.viewer.settings.group.colors.viewer=Viewer colors
+pdf.viewer.settings.group.general=General
+pdf.viewer.settings.viewer.colors=Use custom colors
 pdf.viewer.settings.background=Background:
 pdf.viewer.settings.foreground=Foreground:
 pdf.viewer.settings.icons=Icons:

--- a/web-view/viewer/build.gradle.kts
+++ b/web-view/viewer/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
+
 plugins {
   kotlin("js")
   kotlin("plugin.serialization")
@@ -20,18 +22,24 @@ kotlin {
   js(IR) {
     browser {
       webpackTask {
-        cssSupport.enabled = true
+        cssSupport {
+          enabled.set(true)
+        }
         sourceMaps = true
       }
 
       runTask {
-        cssSupport.enabled = true
+        cssSupport {
+          enabled.set(true)
+        }
       }
 
       testTask {
         useKarma {
           useChromeHeadless()
-          webpackConfig.cssSupport.enabled = true
+          webpackConfig.cssSupport {
+            enabled.set(true)
+          }
         }
       }
     }

--- a/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/Application.kt
+++ b/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/Application.kt
@@ -90,7 +90,7 @@ class Application(private val viewer: ViewerAdapter) {
     }
     pipe.subscribe<IdeMessages.UpdateThemeColors> {
       console.log("Received theme update request $it")
-      updateTheme(it.theme)
+      ThemeUtils.updateColors(it.theme)
     }
     pipe.subscribe<IdeMessages.NavigateTo> {
       viewer.viewerApp.pdfLinkService.navigateTo(it.destination)
@@ -168,14 +168,6 @@ class Application(private val viewer: ViewerAdapter) {
         navigationReference = node.dest
       )
     }
-  }
-
-  private fun updateTheme(viewTheme: ViewTheme) {
-    val appConfig = viewer.viewerApp.asDynamic().appConfig
-    // appConfig.appContainer.style.background = viewTheme.background
-    val document = appConfig.appContainer.ownerDocument as Document
-    ThemeUtils.updateColors(viewTheme)
-    // ThemeUtils.attachStylesheet(document, ThemeUtils.generateStylesheet(viewTheme))
   }
 
   // FIXME: Reimplement document info collection without open/close hack and

--- a/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/Application.kt
+++ b/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/Application.kt
@@ -19,7 +19,6 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromDynamic
 import org.w3c.dom.Document
-import org.w3c.dom.events.Event
 import org.w3c.dom.events.EventListener
 import org.w3c.dom.events.KeyboardEvent
 import org.w3c.dom.events.MouseEvent
@@ -175,7 +174,7 @@ class Application(private val viewer: ViewerAdapter) {
     val appConfig = viewer.viewerApp.asDynamic().appConfig
     // appConfig.appContainer.style.background = viewTheme.background
     val document = appConfig.appContainer.ownerDocument as Document
-    ThemeUtils.updateColors(document, viewTheme)
+    ThemeUtils.updateColors(viewTheme)
     // ThemeUtils.attachStylesheet(document, ThemeUtils.generateStylesheet(viewTheme))
   }
 

--- a/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/pdfjs/ThemeUtils.kt
+++ b/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/pdfjs/ThemeUtils.kt
@@ -5,6 +5,11 @@ import kotlinx.browser.window
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLElement
+import org.w3c.dom.asList
+import org.w3c.dom.css.CSSImportRule
+import org.w3c.dom.css.CSSStyleRule
+import org.w3c.dom.css.CSSStyleSheet
+import org.w3c.dom.css.get
 
 object ThemeUtils {
   // https://github.com/allefeld/atom-pdfjs-viewer/issues/4#issuecomment-622942606
@@ -48,5 +53,26 @@ object ThemeUtils {
       setProperty(Internals.StyleVariables.treeItemColor, viewTheme.foreground)
       setProperty(Internals.StyleVariables.treeItemHoverColor, viewTheme.foreground)
     }
+
+    val css = window.document.styleSheets[0] as CSSStyleSheet
+    val pdfViewerCss =
+      css.cssRules.asList().filterIsInstance<CSSImportRule>().find { it.href == "pdf_viewer.css" }?.styleSheet
+
+    val pageViewerRule = pdfViewerCss?.cssRules?.asList()?.filterIsInstance<CSSStyleRule>()
+      ?.find { it.selectorText == ".pdfViewer .page" } as? CSSStyleRule
+    pageViewerRule?.style?.removeProperty("-o-border-image")
+    pageViewerRule?.style?.removeProperty("border-image")
+
+    val thumbnailRule = css.cssRules.asList().filterIsInstance<CSSStyleRule>().find { it.selectorText == ".thumbnailImage" }
+    thumbnailRule?.style?.removeProperty("box-shadow")
+
+    //language=CSS
+    val rule =
+      """
+      .page, .thumbnailImage {
+        filter: invert(${viewTheme.colorInvertIntensity}%);
+      }
+      """.trimIndent()
+    pdfViewerCss?.insertRule(rule, pdfViewerCss.cssRules.length)
   }
 }

--- a/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/pdfjs/ThemeUtils.kt
+++ b/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/pdfjs/ThemeUtils.kt
@@ -2,8 +2,6 @@ package com.firsttimeinforever.intellij.pdf.viewer.application.pdfjs
 
 import com.firsttimeinforever.intellij.pdf.viewer.model.ViewTheme
 import kotlinx.browser.window
-import org.w3c.dom.Document
-import org.w3c.dom.Element
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.asList
 import org.w3c.dom.css.CSSImportRule
@@ -12,38 +10,7 @@ import org.w3c.dom.css.CSSStyleSheet
 import org.w3c.dom.css.get
 
 object ThemeUtils {
-  // https://github.com/allefeld/atom-pdfjs-viewer/issues/4#issuecomment-622942606
-  fun generateStylesheet(viewTheme: ViewTheme): String {
-    // language=CSS
-    return """
-    .outlineItemToggler.outlineItemsHidden::after {
-      background-color: ${viewTheme.icons};
-    }
-    .outlineItemToggler::after {
-      background-color: ${viewTheme.icons};
-    }
-    .outlineItem > a {
-      color: ${viewTheme.foreground};
-    }
-    #toolbarSidebar {
-      background-color: ${viewTheme.background};
-    }
-    .page, .thumbnailImage {
-      filter: invert(${viewTheme.colorInvertIntensity}%);
-    }
-    """
-  }
-
-  fun attachStylesheet(document: Document, content: String): Element {
-    val head = document.head
-    checkNotNull(head)
-    val element = document.createElement("style")
-    element.textContent = content
-    head.append(element)
-    return element
-  }
-
-  fun updateColors(document: Document, viewTheme: ViewTheme) {
+  fun updateColors(viewTheme: ViewTheme) {
     val documentElement = window.document.documentElement as HTMLElement
     with(documentElement.style) {
       setProperty(Internals.StyleVariables.mainColor, viewTheme.foreground)
@@ -55,24 +22,43 @@ object ThemeUtils {
     }
 
     val css = window.document.styleSheets[0] as CSSStyleSheet
-    val pdfViewerCss =
-      css.cssRules.asList().filterIsInstance<CSSImportRule>().find { it.href == "pdf_viewer.css" }?.styleSheet
+    val pdfViewerCss = css.cssRules.asList().filterIsInstance<CSSImportRule>().find { it.href == "pdf_viewer.css" }?.styleSheet
 
+    // Remove the shadow of the borders independent of if the colors are inverted, so it is consistent when switching between inverted and regular colors.
+    removeBorderShadow(css, pdfViewerCss)
+
+    //language=CSS
+    css.addOrReplaceRule(
+      selectorText = ".page, .thumbnailImage",
+      body = "filter: invert(${viewTheme.colorInvertIntensity}%);"
+    )
+  }
+
+  /**
+   * Remove the shadow around the pages because the shadow looks really strange when inverted.
+   *
+   * @param viewerCss A reference to viewer.css, which contains global styling for the pdf viewer.
+   * @param pdfViewerCss A reference to pdf_viewer.css, which contains styling of the pages view.
+   */
+  private fun removeBorderShadow(viewerCss: CSSStyleSheet, pdfViewerCss: CSSStyleSheet?) {
     val pageViewerRule = pdfViewerCss?.cssRules?.asList()?.filterIsInstance<CSSStyleRule>()
-      ?.find { it.selectorText == ".pdfViewer .page" } as? CSSStyleRule
+      ?.find { it.selectorText == ".pdfViewer .page" }
     pageViewerRule?.style?.removeProperty("-o-border-image")
     pageViewerRule?.style?.removeProperty("border-image")
 
-    val thumbnailRule = css.cssRules.asList().filterIsInstance<CSSStyleRule>().find { it.selectorText == ".thumbnailImage" }
+    val thumbnailRule = viewerCss.cssRules.asList().filterIsInstance<CSSStyleRule>().find { it.selectorText == ".thumbnailImage" }
     thumbnailRule?.style?.removeProperty("box-shadow")
+  }
 
-    //language=CSS
-    val rule =
-      """
-      .page, .thumbnailImage {
-        filter: invert(${viewTheme.colorInvertIntensity}%);
-      }
-      """.trimIndent()
-    pdfViewerCss?.insertRule(rule, pdfViewerCss.cssRules.length)
+  /**
+   * Remove the rule if it already exists, then add the rule.
+   */
+  private fun CSSStyleSheet.addOrReplaceRule(selectorText: String, body: String) {
+    val existingIndex = cssRules.asList().filterIsInstance<CSSStyleRule>().indexOfFirst { it.selectorText == selectorText }
+    if (existingIndex >= 0) {
+      deleteRule(existingIndex)
+    }
+
+    insertRule("$selectorText { $body }", cssRules.length)
   }
 }


### PR DESCRIPTION
Fixes #10 

- Enables color inversion without having to enable it in the registry. (The registry key still exists, let me know if you'd prefer it gone as well.) 
  - Adds an option to automatically apply the color inversion based on theme.
  - These settings are global (for all pdf documents) so there is no dark/light icon in the pdf toolbar.
- Updated IDE version, Kotlin and Java versions, and TeXiFy version.
- Converted the settings page from Kotlin UI DSL 1 to Kotlin UI DSL 2.
- Tested that the color inversion and the new settings page works with the new UI as well as with the old UI.

Some screenshots:
![dark](https://user-images.githubusercontent.com/15685876/234096197-86c6d7a5-f1b4-4e1f-b1a8-33fc0110fcd7.png)
![light](https://user-images.githubusercontent.com/15685876/234096203-845fb336-4760-4716-9ce9-3860cceb0f56.png)
![settings](https://user-images.githubusercontent.com/15685876/234096207-055b6dc5-1e36-4b92-b7dd-6b2ea128a310.png)
