### PR TITLE
Forward search after document is loaded

### DIFF
--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/ui/editor/view/PdfJcefPreviewController.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/ui/editor/view/PdfJcefPreviewController.kt
@@ -240,7 +240,9 @@ class PdfJcefPreviewController(val project: Project, val virtualFile: VirtualFil
 
   fun setForwardSearchData(data: SynctexPreciseLocation) {
     currentForwardSearchData = data
-    pipe.send(IdeMessages.SynctexForwardSearch(data))
+    if (viewLoaded) {
+      pipe.send(IdeMessages.SynctexForwardSearch(data))
+    }
   }
 
   fun canNavigate(): Boolean = outline != null

--- a/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/Application.kt
+++ b/web-view/viewer/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/application/Application.kt
@@ -295,6 +295,7 @@ class Application(private val viewer: ViewerAdapter) {
         pipe.send(BrowserMessages.InitialViewProperties(it))
         notifyViewStateChanged(ViewStateChangeReason.INITIAL)
       }
+      pipe.send(BrowserMessages.AskForwardSearchData())
       with(viewer) {
         addEventListener(ViewerEvents.PAGE_CHANGING, ::pageChangeListener)
         addEventListener(ViewerEvents.ZOOM_IN, ::zoomChangeListener)


### PR DESCRIPTION
Should fix #75.

The forward search itself still is a bit finicky, but that's for #31 :p