### PR TITLE
Fix draft releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
   # If accepted and published, release workflow would be triggered
   release-draft:
     name: Create Release Draft
-    if: github.ref == 'refs/heads/master'
+    # if: github.ref == 'refs/heads/master'
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -93,18 +93,6 @@ jobs:
             | xargs -I '{}' \
           curl -X DELETE -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/$GITHUB_REPOSITORY/releases/{}
 
-      # Create new release draft - which is not publicly visible and requires manual acceptance
-      - name: Create Release Draft
-        id: createDraft
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ needs.build.outputs.version }}
-          release_name: v${{ needs.build.outputs.version }}
-          # body: ${{ needs.build.outputs.changelog }}
-          draft: true
-
       # Download plugin artifact provided by the previous job
       - name: Download Artifact
         uses: actions/download-artifact@v4
@@ -112,13 +100,13 @@ jobs:
           name: plugin-artifact
 
       # Upload artifact as a release asset
-      - name: Upload Release Asset
+      - name: Create Release Draft
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.createDraft.outputs.upload_url }}
-          asset_path: ./plugin-artifact/${{ needs.build.outputs.artifact }}
-          asset_name: ${{ needs.build.outputs.artifact }}
-          asset_content_type: application/zip
+          files: ./plugin-artifact/${{ needs.build.outputs.artifact }}
+          draft: true
+          name: v${{ needs.build.outputs.version }}
+          tag_name: v${{ needs.build.outputs.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: plugin-artifact
+          path: plugin-artifact
 
       # Upload artifact as a release asset
       - name: Create Release Draft
@@ -107,6 +108,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: ./plugin-artifact/${{ needs.build.outputs.artifact }}
+          fail_on_unmatched_files: true
           draft: true
           name: v${{ needs.build.outputs.version }}
           tag_name: v${{ needs.build.outputs.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
   # If accepted and published, release workflow would be triggered
   release-draft:
     name: Create Release Draft
-    # if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The upload-release-asset action is deprecated and was not working anymore, so I replaced it with softprops/action-gh-release