### PR TITLE
set `cMapUrl` (character maps) to support pdf without embedded font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Intellij PDF Viewer Plugin Changelog
+
+## 0.16.1
+- Support pdfs without an embedded font, by [Liu Dongmiao](https://github.com/liudongmiao).
+
 ## 0.16.0
 - Support 2024.1 ([#90](https://github.com/FirstTimeInForever/intellij-pdf-viewer/issues/90), [#98](https://github.com/FirstTimeInForever/intellij-pdf-viewer/issues/98))
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginName = intellij-pdf-viewer
 group = com.firsttimeinforever.intellij.pdf.viewer
-version = 0.16.0
+version = 0.16.1
 
 # To run with AS 2021.3.1 Canary 5
 #platformVersion = 213.6777.52

--- a/web-view/bootstrap/src/ViewerBootstrapper.ts
+++ b/web-view/bootstrap/src/ViewerBootstrapper.ts
@@ -11,6 +11,7 @@ export class ViewerBootstrapper {
       get: () => PDFViewerApplication
     });
     AppOptions.set("workerSrc", "pdf.worker.js");
+    AppOptions.set("cMapUrl", "cmaps/");
     Object.defineProperty(window, "PDFViewerApplicationOptions", {
       get: () => AppOptions
     });


### PR DESCRIPTION
Currently, it cannot access cmaps as the default `cMapUrl` is `../web/cmaps/`, and it's not a valid cmaps, the pdf.js cannot render the pdf without embedded font. Furthermore, it will prevent show other pdf, and show a 404.