### PR TITLE
support pdf files named with special characters and virtual file

### DIFF
--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/jcef/PdfStaticServer.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/jcef/PdfStaticServer.kt
@@ -3,26 +3,33 @@ package com.firsttimeinforever.intellij.pdf.viewer.jcef
 import com.firsttimeinforever.intellij.pdf.viewer.settings.PdfViewerSettings
 import com.firsttimeinforever.intellij.pdf.viewer.utility.PdfResourceLoader
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.Url
 import com.intellij.util.Urls
 import com.intellij.util.io.URLUtil
 import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.http.FullHttpRequest
+import io.netty.handler.codec.http.HttpHeaderNames
+import io.netty.handler.codec.http.HttpMethod
+import io.netty.handler.codec.http.HttpResponseStatus
+import io.netty.handler.codec.http.HttpUtil
 import io.netty.handler.codec.http.QueryStringDecoder
+import io.netty.handler.stream.ChunkedStream
 import org.jetbrains.ide.BuiltInServerManager
 import org.jetbrains.ide.HttpRequestHandler
 import org.jetbrains.io.FileResponses
+import org.jetbrains.io.addKeepAliveIfNeeded
+import org.jetbrains.io.flushChunkedResponse
 import org.jetbrains.io.response
 import org.jetbrains.io.send
-import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.*
-import kotlin.io.path.extension
 import kotlin.random.Random
 
 internal class PdfStaticServer : HttpRequestHandler() {
   private val serverUrl = "http://localhost:${BuiltInServerManager.getInstance().port}/$uuid"
+
+  private val vfsMap = mutableMapOf<String, VirtualFile>()
 
   init {
     logger.debug("Starting static server with url: $serverUrl")
@@ -53,15 +60,32 @@ internal class PdfStaticServer : HttpRequestHandler() {
     return path.startsWith("/get-file/")
   }
 
-  private fun assertValidExternalPath(path: Path) {
-    check(path.extension.lowercase(Locale.getDefault()) == "pdf") { "Only pdf files can be served from the outside of jar!" }
-  }
-
-  private fun sendExternalFile(path: String, context: ChannelHandlerContext, request: FullHttpRequest) {
-    val targetFile = Paths.get(path)
-    assertValidExternalPath(targetFile)
-    logger.debug("Sending external file: $targetFile")
-    FileResponses.sendFile(request, context.channel(), Paths.get(targetFile.toString()))
+  private fun sendExternalFile(url: String, context: ChannelHandlerContext, request: FullHttpRequest) {
+    val file: VirtualFile? = vfsMap[url]
+    val channel = context.channel()
+    if (file == null) {
+      logger.debug("Cannot find pdf file $url")
+      HttpResponseStatus.NOT_FOUND.send(channel, request)
+    } else if (file.isInLocalFileSystem) {
+      val path = Paths.get(file.path)
+      logger.debug("Sending external file, path: $path")
+      FileResponses.sendFile(request, channel, path)
+    } else {
+      logger.debug("Sending external file, url: $url")
+      // see org.jetbrains.builtInWebServer.StaticFileHandler
+      val response = FileResponses.prepareSend(request, channel, file.timeStamp, file.name) ?: return
+      val isKeepAlive = response.addKeepAliveIfNeeded(request)
+      // remove accept-ranges as we don't support
+      response.headers().remove(HttpHeaderNames.ACCEPT_RANGES)
+      if (request.method() != HttpMethod.HEAD) {
+        HttpUtil.setContentLength(response, file.length)
+      }
+      channel.write(response)
+      if (request.method() != HttpMethod.HEAD) {
+        channel.write(ChunkedStream(file.inputStream))
+      }
+      flushChunkedResponse(channel, isKeepAlive)
+    }
   }
 
   private fun makeInternalPath(path: String): String {
@@ -85,14 +109,19 @@ internal class PdfStaticServer : HttpRequestHandler() {
     response.send(context.channel(), request)
   }
 
-  fun getPreviewUrl(filePath: String, withReloadSalt: Boolean = false): String {
+  fun getPreviewUrl(file: VirtualFile, withReloadSalt: Boolean = false): String {
     val salt = if (withReloadSalt) Random.nextInt() else 0
+    vfsMap[file.url] = file
     val url = parseEncodedPath("$serverUrl/index.html")
     val server = BuiltInServerManager.getInstance()
     return server.addAuthToken(url)
       // `file` would be read via `urlDecoder.path()`, which calls `decodeComponent`
-      .addParameters(mapOf("__reloadSalt" to "$salt", "file" to URLUtil.encodeURIComponent("get-file/$filePath")))
+      .addParameters(mapOf("__reloadSalt" to "$salt", "file" to URLUtil.encodeURIComponent("get-file/${file.url}")))
       .toExternalForm()
+  }
+
+  fun disposePreviewUrl(file: VirtualFile) {
+    vfsMap.remove(file.url)
   }
 
   private fun parseEncodedPath(target: String): Url {

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/ui/editor/view/PdfJcefPreviewController.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/ui/editor/view/PdfJcefPreviewController.kt
@@ -129,7 +129,7 @@ class PdfJcefPreviewController(val project: Project, val virtualFile: VirtualFil
   private fun doActualReload(tryToPreserveState: Boolean = false) {
     viewLoaded = false
     try {
-      val base = PdfStaticServer.instance.getPreviewUrl(virtualFile.path, withReloadSalt = true)
+      val base = PdfStaticServer.instance.getPreviewUrl(virtualFile, withReloadSalt = true)
       if (firstLoad) {
         viewState = viewState.copy(sidebarViewMode = PdfViewerSettings.instance.defaultSidebarViewMode)
       }
@@ -255,7 +255,10 @@ class PdfJcefPreviewController(val project: Project, val virtualFile: VirtualFil
     pipe.send(IdeMessages.NavigateHistory(direction))
   }
 
-  override fun dispose() = Unit
+  override fun dispose() {
+    logger.debug("dispose $virtualFile")
+    PdfStaticServer.instance.disposePreviewUrl(virtualFile)
+  }
 
   companion object {
     private val logger = logger<PdfJcefPreviewController>()


### PR DESCRIPTION
1. we need to encode `file` parameter, as `pdf.js` would decode before request
2. we need to encode `file` value, as it would be read via `decodeComponent`

this should fix #29, #84

remote pdf files is encoded with custom protocol, we need to use `VirtualFile` to read content.

this should fix #81