### PR TITLE
Add support for customizing inverse search shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - **Zoom out:** <kbd>Ctrl</kbd> + <kbd>-</kbd>
 - **Reset zoom:** <kbd>Ctrl</kbd> + <kbd>0</kbd>
 - **Enter presentation mode:** <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>p</kbd>
+- **Inverse search (LaTeX):** <kbd>Ctrl</kbd> + <kbd>Left click</kbd> (can be customized in Settings | Keymap to other mouse shortcuts)
 
 ### Feature Notes
 

--- a/model/src/commonMain/kotlin/com/firsttimeinforever/intellij/pdf/viewer/IdeMessages.kt
+++ b/model/src/commonMain/kotlin/com/firsttimeinforever/intellij/pdf/viewer/IdeMessages.kt
@@ -49,6 +49,9 @@ object IdeMessages {
   data class SynctexAvailability(val isAvailable: Boolean)
 
   @Serializable
+  data class InverseSearchShortcuts(val shortcuts: Set<String>)
+
+  @Serializable
   data class NavigateTo(val destination: JsonElement)
 
   @Serializable

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/navigation/PdfInverseSearchAction.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/navigation/PdfInverseSearchAction.kt
@@ -1,0 +1,23 @@
+package com.firsttimeinforever.intellij.pdf.viewer.actions.navigation
+
+import com.firsttimeinforever.intellij.pdf.viewer.actions.PdfAction
+import com.firsttimeinforever.intellij.pdf.viewer.ui.editor.PdfFileEditor
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.fileEditor.FileEditorManager
+
+/**
+ * This is not the actual inverse search action, which is done in SynctexSearchController.
+ * However, we need to provide a way for the user to change the default shortcut.
+ *
+ * @author Thomas
+ */
+class PdfInverseSearchAction : AnAction() {
+  override fun actionPerformed(e: AnActionEvent) {
+    val shortcuts = shortcutSet.shortcuts.map { it.toString() }.toSet()
+    // Send to browser which shortcut should be listened to
+    FileEditorManager.getInstance(e.project ?: return).allEditors.filterIsInstance<PdfFileEditor>().forEach {
+      PdfAction.findController(it)?.setInverseSearchShortcuts(shortcuts)
+    }
+  }
+}

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/ui/editor/view/PdfJcefPreviewController.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/ui/editor/view/PdfJcefPreviewController.kt
@@ -287,6 +287,10 @@ class PdfJcefPreviewController(val project: Project, val virtualFile: VirtualFil
     pipe.send(IdeMessages.NavigateHistory(direction))
   }
 
+  fun setInverseSearchShortcuts(shortcuts: Set<String>) {
+    pipe.send(IdeMessages.InverseSearchShortcuts(shortcuts))
+  }
+
   override fun dispose() {
     logger.debug("dispose $virtualFile")
     PdfStaticServer.instance.disposePreviewUrl(virtualFile)

--- a/plugin/src/main/resources/META-INF/actions.xml
+++ b/plugin/src/main/resources/META-INF/actions.xml
@@ -109,6 +109,16 @@
             class="com.firsttimeinforever.intellij.pdf.viewer.actions.navigation.PdfNavigateByHistoryAction$Forward"
             icon="AllIcons.Actions.Forward"/>
 
+    <!-- Inverse search -->
+    <action id="pdf.viewer.PdfInverseSearchAction"
+            class="com.firsttimeinforever.intellij.pdf.viewer.actions.navigation.PdfInverseSearchAction"
+            text="PDF Inverse Search"
+            description="Sets inverse search shortcut to navigate from the PDF to LaTeX source">
+      <mouse-shortcut keymap="$default" keystroke="control button1"/>
+      <mouse-shortcut keymap="Mac OS X 10.5+" keystroke="meta button1"/>
+      <mouse-shortcut keymap="Mac OS X" keystroke="meta button1"/>
+    </action>
+
     <!--Actions list action-->
     <action id="pdf.viewer.ActionList"
             class="com.firsttimeinforever.intellij.pdf.viewer.actions.PdfActionList"/>


### PR DESCRIPTION
Fix #26

I reused the action performed to send the shortcut to the browser side to make sure it is always up to date.