### PR TITLE
Hide toolbar for diff view

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 pluginName = intellij-pdf-viewer
 group = com.firsttimeinforever.intellij.pdf.viewer
-version = 0.17.1
+version = 0.17.2-alpha.2
 
 # To run with AS 2021.3.1 Canary 5
 #platformVersion = 213.6777.52
 
 #IntelliJ IDEA 2021.1.2 Preview
-platformVersion = 2025.2
+platformVersion = 253.24325.38
 pluginSinceVersion = 241
 pluginVerifierIdeVersions = 241, 252
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,9 +1,8 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import java.nio.file.Files
 import java.nio.file.Paths
-import org.jetbrains.intellij.platform.gradle.TestFrameworkType
-import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 
 fun fromProperties(key: String) = project.findProperty(key).toString()
 
@@ -11,12 +10,12 @@ plugins {
   id("java")
   kotlin("jvm")
   kotlin("plugin.serialization")
-  id("org.jetbrains.intellij.platform") version "2.6.0"
-  id("org.jetbrains.changelog") version "2.2.1"
-  id("com.github.ben-manes.versions") version "0.52.0"
+  id("org.jetbrains.intellij.platform") version "2.9.0"
+  id("org.jetbrains.changelog") version "2.4.0"
+  id("com.github.ben-manes.versions") version "0.53.0"
   // Plugin which can update Gradle dependencies, use the help/useLatestVersions task.
-  id("se.patrikerdes.use-latest-versions") version "0.2.18"
-  id("io.sentry.jvm.gradle") version "5.8.0"
+  id("se.patrikerdes.use-latest-versions") version "0.2.19"
+  id("io.sentry.jvm.gradle") version "6.0.0-alpha.4"
 }
 
 group = fromProperties("group")
@@ -44,12 +43,12 @@ dependencies {
     pluginVerifier()
     testFramework(TestFrameworkType.Platform)
 
-    intellijIdeaCommunity(fromProperties("platformVersion"))
+    intellijIdea(fromProperties("platformVersion"))
 
     plugin("nl.rubensten.texifyidea:${fromProperties("texifyVersion")}")
   }
 
-  implementation("io.sentry:sentry:8.17.0") {
+  implementation("io.sentry:sentry:8.23.0") {
     // Included in IJ
     exclude("org.slf4j")
     exclude("com.fasterxml.jackson.core", "jackson-core")
@@ -96,13 +95,11 @@ intellijPlatform {
     name = fromProperties("pluginName")
     description = extractPluginDescription()
     // Get the latest available change notes from the changelog file
-    changeNotes = (
-      provider {
-        with(changelog) {
-          renderItem(changelog.getLatest().withHeader(true), Changelog.OutputType.HTML)
-        }
+    changeNotes = provider {
+      with(changelog) {
+        renderItem(changelog.getLatest().withHeader(true), Changelog.OutputType.HTML)
       }
-      )
+    }
   }
 
   // Set name of archive https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1731#issuecomment-2372046338

--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/PdfAction.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/PdfAction.kt
@@ -51,9 +51,14 @@ abstract class PdfAction(protected val viewModeAwareness: ViewModeAwareness = Vi
      * is possible that there is a PDF open somewhere, but it is not in view.
      */
     fun findEditorInView(event: AnActionEvent): PdfFileEditor? {
-      val focusedEditor = event.getData(PlatformDataKeys.FILE_EDITOR) as? PdfFileEditor
+      val focusedEditor = event.getData(PlatformDataKeys.FILE_EDITOR)
 
-      return focusedEditor ?: run {
+      if (focusedEditor?.javaClass?.simpleName == "BackendDiffRequestProcessorEditor") {
+        // This is a diff view, which we cannot control, so don't do anything
+        return null
+      }
+
+      return focusedEditor as? PdfFileEditor ?: run {
         val project = event.project ?: return null
         FileEditorManager.getInstance(project).selectedEditors.firstOrNull {it is PdfFileEditor} as? PdfFileEditor
       }

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -12,7 +12,6 @@
   <extensions defaultExtensionNs="com.intellij">
     <fileType name="PDF"
               extensions="pdf"
-              language="PDF"
               fieldName="INSTANCE"
               implementationClass="com.firsttimeinforever.intellij.pdf.viewer.lang.PdfFileType"/>
     <fileEditorProvider implementation="com.firsttimeinforever.intellij.pdf.viewer.ui.editor.PdfFileEditorProvider"/>


### PR DESCRIPTION
See https://github.com/FirstTimeInForever/intellij-pdf-viewer/pull/137#issuecomment-3219488870 
The full toolbar would show when opening a diff view and moving it to a group opposite an open pdf editor (which would be controlled by the toolbar). Now the toolbar will be disabled for diff view.