### PR TITLE
Fix that the spread actions are only visible in IDE presentation mode

### DIFF
--- a/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/view/PdfSetPageSpreadStateAction.kt
+++ b/plugin/src/main/kotlin/com/firsttimeinforever/intellij/pdf/viewer/actions/view/PdfSetPageSpreadStateAction.kt
@@ -2,11 +2,12 @@ package com.firsttimeinforever.intellij.pdf.viewer.actions.view
 
 import com.firsttimeinforever.intellij.pdf.viewer.actions.PdfAction
 import com.firsttimeinforever.intellij.pdf.viewer.actions.PdfToggleAction
+import com.firsttimeinforever.intellij.pdf.viewer.actions.ViewModeAwareness
 import com.firsttimeinforever.intellij.pdf.viewer.model.PageSpreadState
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAware
 
-sealed class PdfSetPageSpreadStateAction(private val targetState: PageSpreadState) : PdfToggleAction(), DumbAware {
+sealed class PdfSetPageSpreadStateAction(private val targetState: PageSpreadState) : PdfToggleAction(ViewModeAwareness.BOTH), DumbAware {
   override fun isSelected(event: AnActionEvent): Boolean {
     val controller = PdfAction.findController(event) ?: return false
     return controller.viewState.pageSpreadState == targetState


### PR DESCRIPTION
Fix #48
Fix #100 

By default toggle actions are only displayed in IDE presentation mode, but that's not the case for the page spread actions. They are toggle actions, but should be visible in all modes.